### PR TITLE
Up Iron Spike output to 8 per craft

### DIFF
--- a/src/main/resources/configDevoted.yml
+++ b/src/main/resources/configDevoted.yml
@@ -1324,7 +1324,7 @@ recipes:
     output:
       Iron_Spike:
         material: IRON_INGOT
-        amount: 2
+        amount: 8
         lore:
         - Iron Reinforced Obsidian Spike
   Diamond Spike:


### PR DESCRIPTION
As it is curently, Iron Spikes outputting 2 per craft makes them prohibitively expensive. This ups their output to 8 spike blocks per craft, making them expensive, but not prohibitively so.