### PR TITLE
Respect version increment due to earlier CivMenu changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
 		<dependency>
 			<groupId>vg.civcraft.mc</groupId>
 			<artifactId>CivMenu</artifactId>
-			<version>1.4.4</version>
+			<version>1.4.5</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
1.4.5 is the only CivMenu version we have installed, so this is needed