### PR TITLE
Fix notes not showing the right titles

### DIFF
--- a/src/main/java/com/github/igotyou/FactoryMod/recipes/PrintNoteRecipe.java
+++ b/src/main/java/com/github/igotyou/FactoryMod/recipes/PrintNoteRecipe.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
+import org.bukkit.craftbukkit.v1_10_R1.inventory.CraftMetaBook;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BookMeta;
@@ -70,10 +71,10 @@ public class PrintNoteRecipe extends PrintBookRecipe {
 				)
 		{
 			List<String> textLines = new ArrayList<String>();
+			TagManager printingPlateTag = new TagManager(printingPlateStack);
 			
-			if(this.secureNote) {			
-				TagManager tag = new TagManager(printingPlateStack);
-				String serialNumber = (String)tag.getString("SN");
+			if(this.secureNote) {
+				String serialNumber = printingPlateTag.getString("SN");
 				textLines.add(serialNumber);
 			}
 			
@@ -83,7 +84,7 @@ public class PrintNoteRecipe extends PrintBookRecipe {
 			
 			ItemMeta paperMeta = paper.getItemMeta();
 			paperMeta.setLore(textLines);
-			paperMeta.setDisplayName(this.title);
+			paperMeta.setDisplayName(ChatColor.RESET + printingPlateTag.getCompound("Book").getString("title"));
 			paper.setItemMeta(paperMeta);
 
 			i.addItem(paper);


### PR DESCRIPTION
Notes used to show up as "Note" and "Secure Note" when crafted with a printing press. Now they properly use the title of the printing plate that was used to craft them.