### PR TITLE
Correct spelling of "browser"

### DIFF
--- a/src/main/java/com/github/igotyou/FactoryMod/commands/commands/Menu.java
+++ b/src/main/java/com/github/igotyou/FactoryMod/commands/commands/Menu.java
@@ -17,7 +17,7 @@ public class Menu extends PlayerCommand {
 	public Menu(String name) {
 		super(name);
 		setIdentifier("fm");
-		setDescription("Opens up the factory brower");
+		setDescription("Opens up the factory browser");
 		setUsage("/fm");
 		setArguments(0, 10);
 	}


### PR DESCRIPTION
The description of the Menu command had the word "browser" incorrectly spelled as "brower".