### PR TITLE
Change redstone activation to be a onesided toggle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>com.github.igotyou</groupId>
 	<artifactId>FactoryMod</artifactId>
 	<packaging>jar</packaging>
-	<version>2.4.0</version>
+	<version>2.4.1</version>
 	<name>FactoryMod</name>
 	<url>https://github.com/DevotedMC/FactoryMod</url>
 

--- a/src/main/java/com/github/igotyou/FactoryMod/interactionManager/FurnCraftChestInteractionManager.java
+++ b/src/main/java/com/github/igotyou/FactoryMod/interactionManager/FurnCraftChestInteractionManager.java
@@ -55,24 +55,17 @@ public class FurnCraftChestInteractionManager implements IInteractionManager {
 	ReinforcementManager rm = FactoryMod.getManager().isCitadelEnabled() ? Citadel
 		.getReinforcementManager() : null;
 	int threshold = FactoryMod.getManager().getRedstonePowerOn();
-	if (factoryBlock.getLocation().equals(fccf.getFurnace().getLocation())) {
-	    if (e.getOldCurrent() >= threshold && e.getNewCurrent() < threshold
-		    && fccf.isActive()) {
-		if ((rm == null || MultiBlockStructure.citadelRedstoneChecks(e
-			.getBlock()))) {
+	if (factoryBlock.getLocation().equals(fccf.getFurnace().getLocation()) && 
+			e.getOldCurrent() >= threshold && e.getNewCurrent() < threshold && 
+			(rm == null || MultiBlockStructure.citadelRedstoneChecks(e
+					.getBlock()))) {
+		if (fccf.isActive()) {
 		    fccf.deactivate();
 		}
-	    } else if (e.getOldCurrent() < threshold
-		    && e.getNewCurrent() >= threshold && !fccf.isActive()) {
-		if (rm == null
-			|| MultiBlockStructure.citadelRedstoneChecks(e
-				.getBlock())) {
-		    fccf.attemptToActivate(null, false);
+		else {
+			fccf.attemptToActivate(null, false);
 		}
-	    } else {
-		return;
-	    }
-	}
+		}
     }
 
     public void blockBreak(Player p, Block b) {


### PR DESCRIPTION
So right now a factory will get activated, if it gets a redstone signal and get deactivated if that redstone signal disappears. This is very limiting, because it requires you to input a constant redstone signal into the factory, which makes both buttons and simple pulse circuits unusable.

This pull would change redstone activation so a disappearing signal is ignored, but an incoming one will toggle the state of the factory, meaning it will turn it on if it's off and vice versa. This would greatly increase the possibilities in regards to redstone automation.