### PR TITLE
Some fixes in code and recipes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>com.github.igotyou</groupId>
 	<artifactId>FactoryMod</artifactId>
 	<packaging>jar</packaging>
-	<version>2.4.1</version>
+	<version>2.4.2</version>
 	<name>FactoryMod</name>
 	<url>https://github.com/DevotedMC/FactoryMod</url>
 

--- a/src/main/java/com/github/igotyou/FactoryMod/ConfigParser.java
+++ b/src/main/java/com/github/igotyou/FactoryMod/ConfigParser.java
@@ -1,15 +1,11 @@
 package com.github.igotyou.FactoryMod;
 
 import static vg.civcraft.mc.civmodcore.util.ConfigParsing.parseItemMap;
+import static vg.civcraft.mc.civmodcore.util.ConfigParsing.parseItemMapDirectly;
 import static vg.civcraft.mc.civmodcore.util.ConfigParsing.parseTime;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.TreeMap;
 
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
@@ -567,22 +563,26 @@ public class ConfigParser {
 		case "PRODUCTION":
 			ConfigurationSection outputSection = config.getConfigurationSection("output");
 			ItemMap output;
+			ItemStack recipeRepresentation;
 			if (outputSection == null) {
 				if (!(parentRecipe instanceof ProductionRecipe)) {
 					output = new ItemMap();
+					recipeRepresentation = null;
 				}
 				else {
 					output = ((ProductionRecipe) parentRecipe).getOutput();
+					recipeRepresentation = ((ProductionRecipe) parentRecipe).getRecipeRepresentation();
 				}
 			}
 			else {
 				output = parseItemMap(outputSection);
+				recipeRepresentation = parseFirstItem(outputSection);
 			}
 			ProductionRecipeModifier modi = parseProductionRecipeModifier(config.getConfigurationSection("modi"));
 			if (modi == null && parentRecipe instanceof ProductionRecipe) {
 				modi = ((ProductionRecipe) parentRecipe).getModifier().clone();
 			}
-			result = new ProductionRecipe(identifier, name, productionTime, input, output, modi);
+			result = new ProductionRecipe(identifier, name, productionTime, input, output, recipeRepresentation, modi);
 			break;
 		case "COMPACT":
 			String compactedLore = config.getString("compact_lore", 
@@ -864,6 +864,20 @@ public class ConfigParser {
 			plugin.info("Parsed recipe " + name);
 		}
 		return result;
+	}
+
+	private static ItemStack parseFirstItem(ConfigurationSection config) {
+		if(config == null) {
+			return null;
+		}
+
+		for(String key : config.getKeys(false)) {
+			ConfigurationSection current = config.getConfigurationSection(key);
+			List<ItemStack> list = parseItemMapDirectly(current).getItemStackRepresentation();
+			return list.size() > 0 ? list.get(0) : null;
+		}
+
+		return null;
 	}
 	
 	private Map <String,String> parseRenames(ConfigurationSection config) {

--- a/src/main/java/com/github/igotyou/FactoryMod/factories/Factory.java
+++ b/src/main/java/com/github/igotyou/FactoryMod/factories/Factory.java
@@ -137,8 +137,8 @@ public abstract class Factory implements Runnable {
 		MaterialData data = furnace.getData();
 		((DirectionalContainer) data).setFacingDirection(facing);
 		furnace.setData(data);
-		furnace.update();
 		furnace.setBurnTime(Short.MAX_VALUE);
+		furnace.update();
 		furnace.getInventory().setContents(oldContents);
 	}
 

--- a/src/main/java/com/github/igotyou/FactoryMod/factories/Sorter.java
+++ b/src/main/java/com/github/igotyou/FactoryMod/factories/Sorter.java
@@ -51,7 +51,7 @@ public class Sorter extends Factory {
 				+ "is attempting to activate " + getLogData());
 		mbs.recheckComplete();
 		if (mbs.isComplete()) {
-			if (pm.powerAvailable()) {
+			if (pm.powerAvailable(1)) {
 				if (sortableMaterialsAvailable()) {
 					FactoryActivateEvent fae = new FactoryActivateEvent(this, p);
 					Bukkit.getPluginManager().callEvent(fae);
@@ -101,8 +101,10 @@ public class Sorter extends Factory {
 	}
 
 	public void run() {
-		if (active && mbs.isComplete() && pm.powerAvailable()
-				&& sortableMaterialsAvailable()) {
+		int powerCounter = pm.getPowerCounter() + updateTime;
+		int fuelCount = powerCounter / pm.getPowerConsumptionIntervall();
+
+		if (active && mbs.isComplete() && pm.powerAvailable(fuelCount) && sortableMaterialsAvailable()) {
 			if (runTime >= sortTime) {
 				mbs.recheckComplete();
 				if (!mbs.isComplete()) {
@@ -121,10 +123,12 @@ public class Sorter extends Factory {
 				if (furnace.getType() != Material.BURNING_FURNACE) {
 					turnFurnaceOn(furnace);
 				}
-				if (pm.getPowerCounter() >= pm.getPowerConsumptionIntervall() - 1) {
-					pm.consumePower();
-					pm.setPowerCounter(0);
-
+				// if we need to consume fuel - then do it
+				if (fuelCount >= 1) {
+					// remove fuel.
+					pm.consumePower(fuelCount);
+					// update power counter to remained time
+					pm.setPowerCounter(powerCounter % pm.getPowerConsumptionIntervall());
 				} else {
 					pm.increasePowerCounter(updateTime);
 				}

--- a/src/main/java/com/github/igotyou/FactoryMod/powerManager/FurnacePowerManager.java
+++ b/src/main/java/com/github/igotyou/FactoryMod/powerManager/FurnacePowerManager.java
@@ -35,16 +35,20 @@ public class FurnacePowerManager implements IPowerManager {
 		return powerCounter;
 	}
 
-	public boolean powerAvailable() {
+	public boolean powerAvailable(int fuelCount) {
 		if (furnace.getType() != Material.FURNACE
 				&& furnace.getType() != Material.BURNING_FURNACE) {
 			return false;
 		}
+
+		if(fuelCount == 0)
+			fuelCount = 1;
+
 		FurnaceInventory fi = ((Furnace) furnace.getState()).getInventory();
 		ItemMap im = new ItemMap();
 		im.addItemStack(fi.getFuel());
 		im.addItemStack(fi.getSmelting());
-		return im.getAmount(fuel) != 0;
+		return im.getAmount(fuel) >= fuelCount;
 	}
 
 	public int getPowerConsumptionIntervall() {
@@ -59,9 +63,11 @@ public class FurnacePowerManager implements IPowerManager {
 		powerCounter = amount;
 	}
 
-	public void consumePower() {
+	public void consumePower(int fuelCount) {
 		FurnaceInventory fi = ((Furnace) furnace.getState()).getInventory();
-		fi.removeItem(fuel);
+
+		for(int i = 0; i < fuelCount; i++)
+			fi.removeItem(fuel);
 	}
 	
 	public int getFuelAmountAvailable() {

--- a/src/main/java/com/github/igotyou/FactoryMod/powerManager/IPowerManager.java
+++ b/src/main/java/com/github/igotyou/FactoryMod/powerManager/IPowerManager.java
@@ -10,12 +10,12 @@ public interface IPowerManager {
 	 * Consumes one unit of power, what that means is up to the concrete
 	 * implementation
 	 */
-	public void consumePower();
+	public void consumePower(int fuelCount);
 
 	/**
 	 * @return Whether power for at least one further tick cycle is available
 	 */
-	public boolean powerAvailable();
+	public boolean powerAvailable(int fuelCount);
 
 	/**
 	 * @return How often power should be consumed when running the factory this

--- a/src/main/java/com/github/igotyou/FactoryMod/recipes/AOERepairRecipe.java
+++ b/src/main/java/com/github/igotyou/FactoryMod/recipes/AOERepairRecipe.java
@@ -144,7 +144,7 @@ public class AOERepairRecipe extends InputRecipe {
 			if (diff >= repairPerEssence
 					&& fac.getMultiBlockStructure().isComplete()
 					&& !fac.isActive()
-					&& fac.getPowerManager().powerAvailable()) {
+					&& fac.getPowerManager().powerAvailable(1)) {
 				int rem = Math.min(essenceCount, diff / repairPerEssence);
 				ItemStack remStack = essence.clone();
 				remStack.setAmount(rem);

--- a/src/main/java/com/github/igotyou/FactoryMod/recipes/ProductionRecipe.java
+++ b/src/main/java/com/github/igotyou/FactoryMod/recipes/ProductionRecipe.java
@@ -24,17 +24,26 @@ import com.github.igotyou.FactoryMod.recipes.scaling.ProductionRecipeModifier;
 public class ProductionRecipe extends InputRecipe {
 	
 	private ItemMap output;
+	private ItemStack recipeRepresentation;
 	private ProductionRecipeModifier modifier;
 	private Random rng;
 	private DecimalFormat decimalFormatting;
 
-	public ProductionRecipe(String identifier, String name, int productionTime, ItemMap inputs, ItemMap output,
-			ProductionRecipeModifier modifier) {
+	public ProductionRecipe(
+			String identifier,
+			String name,
+			int productionTime,
+			ItemMap inputs,
+			ItemMap output,
+			ItemStack recipeRepresentation,
+			ProductionRecipeModifier modifier
+	) {
 		super(identifier, name, productionTime, inputs);
 		this.output = output;
 		this.modifier = modifier;
 		this.rng = new Random();
 		this.decimalFormatting = new DecimalFormat("#.#####");
+		this.recipeRepresentation = recipeRepresentation != null ? recipeRepresentation : new ItemStack(Material.STONE);
 	}
 
 	public ItemMap getOutput() {
@@ -130,15 +139,8 @@ public class ProductionRecipe extends InputRecipe {
 	}
 
 	public ItemStack getRecipeRepresentation() {
-		List<ItemStack> out = getOutput().getItemStackRepresentation();
-		ItemStack res;
-		if (out.size() == 0) {
-			res = new ItemStack(Material.STONE);
-		} else {
-			res = out.get(0);
-		}
-		ISUtils.setName(res, getName());
-		return res;
+		ISUtils.setName(this.recipeRepresentation, getName());
+		return this.recipeRepresentation;
 	}
 
 	public ProductionRecipeModifier getModifier() {

--- a/src/main/resources/configDevoted.yml
+++ b/src/main/resources/configDevoted.yml
@@ -4116,7 +4116,7 @@ recipes:
         amount: 2
     output:
       Activator Rails:
-        material: DETECTOR_RAIL
+        material: ACTIVATOR_RAIL
         amount: 32
   Craft Red Netherbrick:
     type: PRODUCTION


### PR DESCRIPTION
1. Fixed fuel consume - now amount of used fuel is exactly as it supposed to be.
Previously it always consumed at least 1 fuel less per run than shown in /fm

2. Fixed furnace flashing when factory activated.

3. Make so first item of output in PRODUCTION recipe is always used as 'recipe representation'.
This is especially useful for "Forge Power Rails" recipe where instead of "powered rails" shown bucket.

4. Fixed "Forge Activator Rails" recipe, so it actually craft activator rails but not detector rails.